### PR TITLE
Fix for job ids starting with a dash

### DIFF
--- a/2_get_archive_ids.sh
+++ b/2_get_archive_ids.sh
@@ -4,5 +4,5 @@
 MY_INPUT=job_status.json
 
 for X in `jq -c '[.JobList[].VaultARN,.JobList[].JobId]' $MY_INPUT | tr -d '[]"' | cut -d/ -f2`; do IFS=','; set -- $X;
-	aws glacier get-job-output --account-id $ACCOUNT_ID --vault-name $1 --job-id $2 $1.ids
+	aws glacier get-job-output --account-id $ACCOUNT_ID --vault-name $1 --job-id="$2" $1.ids
 done


### PR DESCRIPTION
Hello, I changed a little the command line of file 2_get_archive_ids.sh in case you have a job id that starts with a dash